### PR TITLE
Add support for osu:// links

### DIFF
--- a/osu-wine
+++ b/osu-wine
@@ -94,6 +94,9 @@ if [ -f "$1" ]; then
         $PREFIXCOMMAND wine "X:/osu!.exe" "$file"
     done
     exit 0
+elif [[ "$1" =~ osu:// ]]; then
+    ## pass osu:// links to osu!
+    $PREFIXCOMMAND wine "X:/osu!.exe" "$1"
 else
     $PREFIXCOMMAND wine "X:/osu!.exe"
 fi

--- a/osu-wine.desktop
+++ b/osu-wine.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Name=osu!
 Comment=osu!
+MimeType=x-scheme-handler/osu
 Type=Application
-Exec=osu-wine
+Exec=osu-wine %U
 Icon=osu-wine
 Terminal=false
 Categories=Wine;Game;


### PR DESCRIPTION
- Register osu:// links for `osu-wine.desktop` with `x-scheme-handler/osu`
- Pass the link to `osu-wine` in `osu-wine.desktop`
- Pass the argument to osu! if it is a link (ie. starts with "osu://")